### PR TITLE
chore: relayer - update organisation name to sprinter

### DIFF
--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -53,7 +53,7 @@ jobs:
       - name: checkout ecs repo
         uses: actions/checkout@v3
         with:
-          repository: sygmaprotocol/devops
+          repository: sprintertech/devops
           token: ${{ secrets.GHCR_TOKEN }}
 
       - name: render jinja2 templates to task definition json files
@@ -125,7 +125,7 @@ jobs:
       - name: checkout ecs repo
         uses: actions/checkout@v3
         with:
-          repository: sygmaprotocol/devops
+          repository: sprintertech/devops
           token: ${{ secrets.GHCR_TOKEN }}
 
       - name: render jinja2 templates to task definition json files

--- a/.github/workflows/deploy_testnet.yml
+++ b/.github/workflows/deploy_testnet.yml
@@ -74,7 +74,7 @@ jobs:
       - name: checkout ecs repo
         uses: actions/checkout@v4
         with:
-          repository: sygmaprotocol/devops
+          repository: sprintertech/devops
           token: ${{ secrets.GHCR_TOKEN }}
 
       - name: render jinja2 templates to task definition json files
@@ -133,7 +133,7 @@ jobs:
       - name: checkout ecs repo
         uses: actions/checkout@v4
         with:
-          repository: sygmaprotocol/devops
+          repository: sprintertech/devops
           token: ${{ secrets.GHCR_TOKEN }}
 
       - name: render jinja2 templates to task definition json files

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -11,7 +11,7 @@ x-logging:
 
 services:
   mempool-stub:
-    image: ghcr.io/sygmaprotocol/beacon-api-stub
+    image: ghcr.io/sprintertech/beacon-api-stub
     container_name: mempool-stub
     labels:
       logging: "promtail"
@@ -26,7 +26,7 @@ services:
 
   bitcoin:
 #   image: ruimarinho/bitcoin-core:latest
-    image: ghcr.io/sygmaprotocol/bitcoin
+    image: ghcr.io/sprintertech/bitcoin
     container_name: bitcoin
     labels:
       logging: "promtail"
@@ -46,7 +46,7 @@ services:
     logging: *default-logging
 
   evm1-1:
-    image: ghcr.io/sygmaprotocol/sygma-solidity:evm1-v2.10.1
+    image: ghcr.io/sprintertech/sygma-solidity:evm1-v2.10.1
     container_name: evm1-1
     command: --chain.chainId 1337 --db data/ --blockTime 2 --m 'black toward wish jar twin produce remember fluid always confirm bacon slush' > /dev/null
     labels:
@@ -57,7 +57,7 @@ services:
       - "8545:8545"
 
   evm2-1:
-    image: ghcr.io/sygmaprotocol/sygma-solidity:evm2-v2.10.1
+    image: ghcr.io/sprintertech/sygma-solidity:evm2-v2.10.1
     command: --chain.chainId 1338 --db data/ --blockTime 2 --m 'black toward wish jar twin produce remember fluid always confirm bacon slush' > /dev/null
     container_name: evm2-1
     labels:
@@ -68,7 +68,7 @@ services:
       - "8547:8545"
 
   substrate-pallet:
-    image: "ghcr.io/sygmaprotocol/sygma-substrate-pallets:e2e-v0.3.1"
+    image: "ghcr.io/sprintertech/sygma-substrate-pallets:e2e-v0.3.1"
     container_name: substrate-pallet
     labels:
       logging: "promtail"


### PR DESCRIPTION
## GitHub Organisation Name Change from Sygmaprotocol to Sprintertech

## Description
Updated the GitHub name to sprinter API

## Related Issue Or Context

Related: #[issues 588](https://github.com/sprintertech/devops/issues/588#issue-2784021910)